### PR TITLE
ランキング画面　表示エラー/＃170

### DIFF
--- a/resources/views/ranking.blade.php
+++ b/resources/views/ranking.blade.php
@@ -18,13 +18,16 @@
                 <div class="col-sm-12 mb-5">
                     <div class="video text-left d-inline-block">
                         {{-- ニックネーム表示 --}}
+                        {{-- @php --}}
+                            {{-- dd($user) --}}
+                        {{-- @endphp --}}
                         ＠{{ $video->user->nickname }}
                         <div>
                             {{-- 動画を表示 --}}
                             @if($video)
-                            <iframe width="580" height="326.25" src="{{ 'https://www.youtube.com/embed/'.$video->url }}?controls=1&loop=1&playlist={{ $video->url }}" frameborder="0"></iframe>
+                                <iframe width="580" height="326.25" src="{{ 'https://www.youtube.com/embed/'.$video->url }}?controls=1&loop=1&playlist={{ $video->url }}" frameborder="0"></iframe>
                             @else
-                            <iframe width="580" height="326.25" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
+                                <iframe width="580" height="326.25" src="https://www.youtube.com/embed/" frameborder="0"></iframe>
                             @endif
                         </div>
                         <p>

--- a/resources/views/ranking.blade.php
+++ b/resources/views/ranking.blade.php
@@ -18,9 +18,6 @@
                 <div class="col-sm-12 mb-5">
                     <div class="video text-left d-inline-block">
                         {{-- ニックネーム表示 --}}
-                        {{-- @php --}}
-                            {{-- dd($user) --}}
-                        {{-- @endphp --}}
                         ＠{{ $video->user->nickname }}
                         <div>
                             {{-- 動画を表示 --}}

--- a/resources/views/users.blade.php
+++ b/resources/views/users.blade.php
@@ -4,11 +4,11 @@
 
 @section('content')
 <div class="container">
-    {{-- 検索機能未実装--}}
+    {{--　検索機能未実装--}}
     {{-- <div class="mt-5 mb-5">
         <h4>おすすめ検索</h4>
     </div> --}}
-    {{-- {!! Form::open(['route'=>' . ']) !!} --}}
+    {{--　{!! Form::open(['route'=>' . ']) !!} --}}
     {{-- <div class="form-check-inline">
         <div class="custom-control custom-checkbox">
             <input class="custom-control-input" type="checkbox" id="custom-check1">
@@ -35,25 +35,26 @@
     </div>
     {!! Form::submit('検索',['class'=> 'button btn btn-primary mt-5 mb-5']) !!} --}}
 
+
     <div class="mt-5 mb-5">
         <h4>みんなの動画</h4>
     </div>
     <div class="video row mt-5 text-center">
         @foreach ($users as $key => $user)
+
         @php
-            $video=$user;
+
+        $video=$user;
+
         @endphp
-            {{-- 動画を横に3つずつ表示させる --}}
             @if($loop->iteration % 3 == 1 && $loop->iteration != 1)
                 </div>
                 <div class="row text-center mt-3">
             @endif
                 <div class="col-lg-4 mb-5">
                     <div class="video text-left d-inline-block">
-                        {{-- ニックネーム表示 --}}
                         ＠{{ $video->user->nickname }}
                         <div>
-                            {{-- 動画を表示 --}}
                             @if($video)
                                 <iframe width="290" height="163.125" src="{{ 'https://www.youtube.com/embed/'.$video->url }}?controls=1&loop=1&playlist={{ $video->url }}" frameborder="0"></iframe>
                             @else
@@ -61,12 +62,12 @@
                             @endif
                         </div>
                         <p>
-                            {{-- 対象学年表示 --}}
-                            おすすめ：{{ $video->target['target_grade'] }}さん
+                        おすすめ：{{ $video->target['target_grade'] }}さん
                         </p>
                     </div>
                 </div>
         @endforeach
     </div>
 </div>
+
 @endsection


### PR DESCRIPTION
close #170 
ランキング画面のニックネーム表示・対象学年表示でエラーになっている
ランキング画面が表示するようにする
・rankimg.balde.php でdd()を行いどこまで、nicknameや、対象学年が流れてきているか調べる
・DBを再度、migrate:refresh --seedを行い、再構築
結果：ランキング画面のエラーが消えて、元踊りに表示するようになった。
原因：DBを変に扱ってしまい、壊れていたようだ

➜実装済み