### PR TITLE
heroku上でのエラーを解消②#175

### DIFF
--- a/database/migrations/2021_03_03_043120_create_videos_table.php
+++ b/database/migrations/2021_03_03_043120_create_videos_table.php
@@ -18,7 +18,7 @@ class CreateVideosTable extends Migration
             $table->integer('user_id')->unsigned()->index()->comment('ユーザID');
             $table->string('url', 11)->comment('URL');
             $table->integer('target_id')->unsigned()->comment('対象ID');
-            $table->timestamps();
+            $table->timestamps(); //登録日時・更新日時
 
 
             //ユーザIDの外部キー制約


### PR DESCRIPTION
close #175 
heroku上でのエラーを解消②

ランキング画面が表示しない
➜ランキング画面が表示するようになった

エラー原因は、env.ファイルに記載したAPI_KEY
herokuでは、env.ファイルはリンクしないので、API_KEYがないというエラーだった。
・heroku config:set API_KEY＝〇〇
上記を行いherokuへAPI_KEYを上げた
再度、migrate:refresh --seed

➜実装済み