### PR TITLE
全てのページをhttps化 #196

### DIFF
--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array|string
      */
-    protected $proxies;
+    protected $proxies = '**';
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
close #196 
一部ページで、http://表記され、エラー画面が出てしまう。
全てのページをhttps化したい
＜解消方法＞
App\Http\Middleware\TrustProxies　に、
protected $proxies = '**';
を追加

➜実装済み

