### PR TITLE
footer ログイン時の動画登録ボタンのリンク先変更 #272

### DIFF
--- a/resources/views/layout/footer.blade.php
+++ b/resources/views/layout/footer.blade.php
@@ -59,7 +59,7 @@
                     </a>
                 </li>
                 <li class="nav-item mx-4">
-                    <a class="nav-link text-light faa-parent  animated-hover" href="/login">
+                    <a class="nav-link text-light faa-parent  animated-hover" href="/videos/create">
                         <i class="fa fa-caret-square-right faa-bounce fa-fw"></i>
                         動画登録
                     </a>


### PR DESCRIPTION
close #272 
footer ログイン時の動画登録ボタンのリンク先変更 #272
- footer.blade.php  
      リンク先を、「ログイン/新規登録」➜「動画登録画面」へ変更

➜実装済み